### PR TITLE
[spec] chore: PR previews (Vercel) + teardown + sweep

### DIFF
--- a/.github/workflows/pr-preview-teardown.yml
+++ b/.github/workflows/pr-preview-teardown.yml
@@ -1,0 +1,55 @@
+name: PR Preview Teardown
+
+on:
+  pull_request:
+    types: [unlabeled, closed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to teardown'
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+jobs:
+  teardown:
+    name: Delete preview deployments for PR
+    if: >
+      (github.event_name == 'workflow_dispatch')
+      || (github.event.action == 'unlabeled' && github.event.label.name == 'preview')
+      || (github.event.action == 'closed')
+    runs-on: ubuntu-latest
+    steps:
+      - id: meta
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "pr=${{ inputs.pr }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Find deployments by meta.pr
+        id: list
+        env:
+          PR: ${{ steps.meta.outputs.pr }}
+        run: |
+          curl -fsSL -H "Authorization: Bearer $VERCEL_TOKEN" \
+            "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT_ID&meta-pr=$PR&limit=100" \
+            > /tmp/deploys.json || echo '{"deployments":[]}' > /tmp/deploys.json
+          ids=$(jq -r '.deployments[].uid' /tmp/deploys.json)
+          echo "ids=$ids" >> "$GITHUB_OUTPUT"
+
+      - name: Delete deployments
+        if: steps.list.outputs.ids != ''
+        run: |
+          for id in ${{ steps.list.outputs.ids }}; do
+            echo "Deleting $id"
+            curl -fsS -X DELETE -H "Authorization: Bearer $VERCEL_TOKEN" \
+              "https://api.vercel.com/v13/deployments/$id" || true
+          done
+

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,140 @@
+name: PR Preview (Vercel, label-gated)
+
+on:
+  pull_request:
+    types: [labeled, reopened, synchronize]
+    paths:
+      - 'web/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/pr-preview.yml'
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number (manual run)'
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number || inputs.pr }}-web
+  cancel-in-progress: true
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  PREVIEW_API_ORIGIN: ${{ vars.PREVIEW_API_ORIGIN || 'https://cerply-api-staging-latest.onrender.com' }}
+
+jobs:
+  gate:
+    name: Gate (label present?)
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'workflow_dispatch')
+      || (github.event_name == 'pull_request'
+          && contains(toJson(github.event.pull_request.labels), '"preview"'))
+    outputs:
+      pr_number: ${{ steps.meta.outputs.pr_number }}
+    steps:
+      - id: meta
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.pr }}" ]]; then
+            echo "pr_number=${{ inputs.pr }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy:
+    name: Build & Deploy Preview
+    needs: gate
+    if: ${{ needs.gate.outputs.pr_number != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+
+      - name: Cache npm (root only)
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+
+      - name: Install deps (root)
+        run: npm ci
+
+      - name: Pull Vercel project (preview)
+        run: |
+          npx vercel --version
+          npx vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
+
+      - name: Build (inject preview API origin)
+        run: |
+          export NEXT_PUBLIC_API_BASE="${PREVIEW_API_ORIGIN}"
+          npx vercel build --token "$VERCEL_TOKEN"
+
+      - name: Deploy preview (soft-fail on rate limit)
+        id: deploy
+        continue-on-error: true
+        env:
+          PR: ${{ needs.gate.outputs.pr_number }}
+        run: |
+          set -o pipefail
+          out=$(npx vercel deploy --prebuilt \
+                --token "$VERCEL_TOKEN" \
+                --scope "$VERCEL_ORG_ID" \
+                --meta pr="$PR" \
+                --yes 2>&1 | tee /tmp/vercel.out) || true
+
+          url=$(grep -Eo 'https://[a-z0-9-]+\.vercel\.app' /tmp/vercel.out | tail -n1 || true)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+          if echo "$out" | grep -Eqi 'rate limit|429|Exceeded usage'; then
+            echo "rate_limited=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -z "$url" ]; then
+            echo "deploy_failed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+      - name: Comment with preview URL
+        if: steps.deploy.outputs.url != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: preview-url
+          recreate: true
+          message: |
+            ✅ **PR Preview ready**
+            URL: ${{ steps.deploy.outputs.url }}
+            _Auto-expires in 48h or when the **preview** label is removed / PR closes._
+
+      - name: Neutral check on rate limit
+        if: steps.deploy.outputs.rate_limited == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            await github.rest.checks.create({
+              owner, repo,
+              name: 'PR Preview',
+              head_sha: context.payload.pull_request?.head?.sha || context.sha,
+              status: 'completed',
+              conclusion: 'neutral',
+              output: {
+                title: 'Preview skipped (Vercel rate limit)',
+                summary: 'Free plan limit hit. Preview not created. Merge is not blocked.'
+              }
+            })
+

--- a/.github/workflows/preview-sweep.yml
+++ b/.github/workflows/preview-sweep.yml
@@ -1,0 +1,44 @@
+name: Preview Sweep (48h auto-expiry)
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: List preview deployments
+        run: |
+          curl -fsSL -H "Authorization: Bearer $VERCEL_TOKEN" \
+            "https://api.vercel.com/v6/deployments?projectId=$VERCEL_PROJECT_ID&limit=100" \
+            > /tmp/deploys.json
+          jq '[.deployments[] | select(.meta.pr != null)]' /tmp/deploys.json > /tmp/preview.json
+
+      - name: Delete stale or orphan previews
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          now_ms=$(date +%s000)
+          while read -r uid pr created; do
+            age_ms=$((now_ms - created))
+            too_old=$(( age_ms > 172800000 ? 1 : 0 )) # 48h
+            state=$(gh api repos/${{ github.repository }}/pulls/$pr --jq .state 2>/dev/null || echo "missing")
+            has_label=$(gh api repos/${{ github.repository }}/issues/$pr/labels --jq '.[]?.name' 2>/dev/null | grep -xc 'preview' || true)
+
+            if [[ "$state" != "open" || "$has_label" -eq 0 || "$too_old" -eq 1 ]]; then
+              echo "Deleting $uid (PR #$pr, state=$state, has_label=$has_label, age_ms=$age_ms)"
+              curl -fsS -X DELETE -H "Authorization: Bearer $VERCEL_TOKEN" \
+                "https://api.vercel.com/v13/deployments/$uid" || true
+            fi
+          done < <(jq -r '.[] | [.uid, .meta.pr, .created] | @tsv' /tmp/preview.json)
+

--- a/docs/runbooks/pr-previews.md
+++ b/docs/runbooks/pr-previews.md
@@ -1,0 +1,33 @@
+# PR Preview Deploys (opt-in, label-gated)
+
+**What it does**
+- Add the `preview` label to a PR → deploys a Vercel preview of **web**.
+- Posts a sticky PR comment with the preview URL.
+- Auto-tears down when you remove the label or close the PR.
+- Nightly sweep deletes previews older than **48h** or orphaned PRs.
+- Vercel free-plan rate limits → job posts a **neutral** check and never blocks merges.
+
+**When to use**
+- UI reviews, stakeholder demos, or QA on PRs that touch `web/**`.
+
+**How to use**
+1) Ensure secrets exist: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.  
+2) (One-time) create label: `preview`.  
+3) Add label to your PR → wait for the comment with the URL.  
+4) Remove label / close PR to tear down.
+
+**Env & Routing**
+- Previews use `NEXT_PUBLIC_API_BASE=${PREVIEW_API_ORIGIN}` (defaults to staging-latest).
+- No changes to prod/staging release workflows.
+
+**Failure modes**
+- **429 / limit hit** → preview skipped; neutral check; merge unblocked.
+- Any other deploy error → also non-blocking; see job logs.
+
+**Costs**
+- Opt-in only. Nightly sweep curbs orphan costs.
+
+**Do not**
+- Reintroduce legacy hosts, raw Render hooks, non-amd64 images, or per-workspace installs.
+
+


### PR DESCRIPTION
Adds label-gated Vercel PR previews with neutral rate-limit handling; auto-teardown; nightly sweep; runbook + README note.