### PR TITLE
[spec] fix: PR preview gate step working dir

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -14,10 +14,6 @@ permissions:
   pull-requests: write
   checks: write
 
-defaults:
-  run:
-    working-directory: web
-
 concurrency:
   group: pr-preview-${{ github.event.pull_request.number || inputs.pr }}-web
   cancel-in-progress: true
@@ -75,17 +71,20 @@ jobs:
         run: npm ci
 
       - name: Pull Vercel project (preview)
+        working-directory: web
         run: |
           npx vercel --version
           npx vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
 
       - name: Build (inject preview API origin)
+        working-directory: web
         env:
           NEXT_PUBLIC_API_BASE: ${{ env.PREVIEW_API_ORIGIN }}
         run: npx vercel build --token "$VERCEL_TOKEN"
 
       - name: Deploy preview (soft-fail on rate limit)
         id: deploy
+        working-directory: web
         continue-on-error: true
         env:
           PR: ${{ needs.gate.outputs.pr_number }}


### PR DESCRIPTION
Remove global defaults.run; scope web/ only to Vercel steps. Gate now runs at repo root.