### PR TITLE
[spec] fix: vercel at repo root for PR preview

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -71,20 +71,17 @@ jobs:
         run: npm ci
 
       - name: Pull Vercel project (preview)
-        working-directory: web
         run: |
           npx vercel --version
           npx vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
 
       - name: Build (inject preview API origin)
-        working-directory: web
         env:
           NEXT_PUBLIC_API_BASE: ${{ env.PREVIEW_API_ORIGIN }}
         run: npx vercel build --token "$VERCEL_TOKEN"
 
       - name: Deploy preview (soft-fail on rate limit)
         id: deploy
-        working-directory: web
         continue-on-error: true
         env:
           PR: ${{ needs.gate.outputs.pr_number }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -14,10 +14,6 @@ permissions:
   pull-requests: write
   checks: write
 
-defaults:
-  run:
-    working-directory: web
-
 concurrency:
   group: pr-preview-${{ github.event.pull_request.number || inputs.pr }}-web
   cancel-in-progress: true
@@ -75,17 +71,20 @@ jobs:
         run: npm ci
 
       - name: Pull Vercel project (preview)
+        working-directory: web
         run: |
           npx vercel --version
           npx vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
 
       - name: Build (inject preview API origin)
+        working-directory: web
         env:
           NEXT_PUBLIC_API_BASE: ${{ env.PREVIEW_API_ORIGIN }}
         run: npx vercel build --token "$VERCEL_TOKEN"
 
       - name: Deploy preview (soft-fail on rate limit)
         id: deploy
+        working-directory: web
         continue-on-error: true
         env:
           PR: ${{ needs.gate.outputs.pr_number }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: 'package.json'
+          node-version: '20.x'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
 


### PR DESCRIPTION
Remove step-level working-directory: web to avoid web/web path; keep root npm ci.