### PR TITLE
[spec] fix: robust PR preview gate

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -71,17 +71,20 @@ jobs:
         run: npm ci
 
       - name: Pull Vercel project (preview)
+        working-directory: .
         run: |
           npx vercel --version
           npx vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
 
       - name: Build (inject preview API origin)
+        working-directory: .
         env:
           NEXT_PUBLIC_API_BASE: ${{ env.PREVIEW_API_ORIGIN }}
         run: npx vercel build --token "$VERCEL_TOKEN"
 
       - name: Deploy preview (soft-fail on rate limit)
         id: deploy
+        working-directory: .
         continue-on-error: true
         env:
           PR: ${{ needs.gate.outputs.pr_number }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -71,20 +71,17 @@ jobs:
         run: npm ci
 
       - name: Pull Vercel project (preview)
-        working-directory: web
         run: |
           npx vercel --version
           npx vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
 
       - name: Build (inject preview API origin)
-        working-directory: web
         env:
           NEXT_PUBLIC_API_BASE: ${{ env.PREVIEW_API_ORIGIN }}
         run: npx vercel build --token "$VERCEL_TOKEN"
 
       - name: Deploy preview (soft-fail on rate limit)
         id: deploy
-        working-directory: web
         continue-on-error: true
         env:
           PR: ${{ needs.gate.outputs.pr_number }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -28,10 +28,6 @@ jobs:
   gate:
     name: Gate (label present?)
     runs-on: ubuntu-latest
-    if: >
-      (github.event_name == 'workflow_dispatch')
-      || (github.event_name == 'pull_request'
-          && contains(toJson(github.event.pull_request.labels), '"preview"'))
     outputs:
       pr_number: ${{ steps.meta.outputs.pr_number }}
     steps:
@@ -46,7 +42,7 @@ jobs:
   deploy:
     name: Build & Deploy Preview
     needs: gate
-    if: ${{ needs.gate.outputs.pr_number != '' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.fork == false) }}
+    if: ${{ needs.gate.outputs.pr_number != '' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(toJson(github.event.pull_request.labels), '"preview"') && github.event.pull_request.head.repo.fork == false)) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Remove job-level gate if; enforce label in deploy job; keep Node 20.x; root npm ci; vercel steps at root.