### PR TITLE
[spec] fix: sticky comment on manual dispatch

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -109,6 +109,7 @@ jobs:
         if: steps.deploy.outputs.url != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          number: ${{ needs.gate.outputs.pr_number }}
           header: preview-url
           recreate: true
           message: |


### PR DESCRIPTION
Add number: ${{ needs.gate.outputs.pr_number }} so the sticky comment posts to the correct PR on workflow_dispatch.