### PR TITLE
docs: establish SSOT (BRD v1.2, Tech v1.2) + operator guide [spec]

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,3 +308,9 @@ interface Score {
 - Extend `scripts/smoke-stg.sh` later to include `GET /api/health`, `GET /api/prompts`, and a lightweight `GET /v1/assignments/today` once live.
 
 > No fancy arrows in headers or examples; keep ASCII for Edge runtime compatibility.
+
+## Preview Deploys (opt-in)
+PR-based previews are label-gated and auto-expire after 48h. They do not block merges and soft-fail on rate limits.
+- Add the  label on a PR to create a preview; remove it to tear down.
+- A nightly sweep removes any orphans older than 48h.
+- See: [PR Previews runbook](docs/runbooks/pr-previews.md)

--- a/docs/brd/cerply-brd.md
+++ b/docs/brd/cerply-brd.md
@@ -1,0 +1,56 @@
+# Cerply — Business Requirements (BRD)
+Version: v1.2
+Status: AUTHORITATIVE — single source of truth for business requirements
+Owner: Product (Robert Ford)
+Changelog: see History section at bottom
+
+SSOT: This document is the authoritative source for business requirements. Every technical delivery must reference a BRD requirement ID.
+
+## 1) Elevator Pitch
+One-liner: What will you master today? Cerply turns any prompt, note, link, or policy into adaptive lessons, quizzes, and spaced reviews. For teams, it produces Certified training packs with audit trails, SLAs, and telemetry.
+
+## 2) Core Benefits
+- Learners: bite-size steps, spaced reviews, always a next best item.
+- Managers/L&D: certified training packs from internal policies; progress/risk visibility; export to GitHub/Notion/Jira.
+- Orgs: faster onboarding & compliance; auditable content lineage; predictable infra & costs.
+
+## 3) Moats
+- Certified multi-agent pipeline: reproducible, auditable outputs (planner + two proposals + checker with citation verification -> locked content).
+- Trust telemetry: per-item lineage, reviewer sign-off, measurable learning outcomes tied to revisions.
+- Infra rigor: header-verified images and non-blocking, label-gated previews with auto-expiry.
+- Content network effects: Certified catalog + internal packs become reusable templates & benchmarks.
+- GTM wedge: publish 150+ Certified items; bundle Certified + IMA packs in pilots.
+
+## 4) Certification Flavors (Business-facing)
+- Highly Rated (organic): community/learner upvotes + outcomes; appears in public recommendations.
+- Cerply Certified (multi-LLM curated):
+  - Planner (LLM-1) builds scope & structure.
+  - Proposers (LLM-2, LLM-3) generate candidates.
+  - Checker (LLM-4) validates claims against real, credible citations and flags gaps.
+  - Pipeline converges; content is locked with audit trail & metadata.
+- Industry Certified (human-in-the-loop): subject-matter expert ratifies content. Primary for corporate/formal training.
+
+## 5) Product Requirements (MVP)
+B1. Learning Flow: create project -> ingest brief/source -> plan -> lessons -> quizzes -> spaced review.
+B2. Adaptive Learning: flexible adjustments based on progress, strengths, preferences (topical difficulty, format, cadence).
+B3. Group Learning: users can push topics to a group and track group stats (org teams, parents, friends).
+B4. Certified Pipeline: multi-LLM converge with citations; human ratification for Industry Certified.
+B5. Exports & Sharing: GitHub Issues exporter (repo/label picker), Markdown export, shareable read-only URL.
+B6. Access & Pricing:
+- Consumers (Free): limited concurrent topics; no access to Certified content.
+- Certified Access: All-in subscription or pay-as-you-go.
+B7. Platforms: Web first; iOS/Android (consumer & corporate) planned; corporate apps aligned to enterprise security.
+B8. Ops Guarantees: staging & prod available; version endpoint and headers present; previews are label-gated, auto-expire <=48h, never block merges.
+B9. Success Metrics: TTFP < 60s; >=80% receive scheduled reviews in week one; >=150 Certified items published; >=3 design partners on Certified + IMA packs.
+
+## Appendix A — GTM (Authoritative Marketing Plan)
+Audience: L&D leaders, compliance managers, eng managers.
+Motion: content-led (publish Certified), founder demos, design partner pilots.
+Channels: site + waitlist, LinkedIn/communities, partner intros, webinars.
+Offers: Certified + IMA pack pilot (setup + 30-day success plan).
+KPIs: waitlist->demo, demo->pilot, content->inbound, pilot NPS, conversion to paid.
+
+---
+
+## History
+- v1.2 (2025-09-19): Consolidated BRD; added certification flavors; adaptive/group learning; pricing; platforms; GTM as appendix.

--- a/docs/epics/2025-09-ci-staging-prod-hardening.md
+++ b/docs/epics/2025-09-ci-staging-prod-hardening.md
@@ -55,3 +55,23 @@ grep -Ei '^(x-image-(tag|revision|created)|x-runtime-channel|x-api):' /tmp/h
 
 ## Owners
 - Infra/DevOps: @robnreb1
+
+### 2025-09-18 — Status: **COMPLETE** — Safe PR Preview Deployments + Rate-Limit Guardrails
+
+**What shipped**
+- Label-gated PR previews with sticky URL comment.
+- Robust URL capture; explicit PR-numbered sticky comment.
+- Soft-fail on Vercel rate limit (neutral).
+- Teardown on unlabel/close + nightly 48h sweep.
+- Legacy “Deploy to Vercel” preview job gated on  and now runs  +  before  (in ); prod job untouched.
+- Web Smoke hardened (timeouts/retries) and honors  input.
+- Ingest aliases forward headers (cookies + custom) to avoid 401s when auth is required.
+- README + runbook updated.
+
+**Verification**
+- Staging API headers (source of truth):
+- (headers not fetched)
+
+**Acceptance ✅** Met for label gating, soft-fail, teardown, nightly cleanup, and docs.
+
+_Recorded on 2025-09-18, main @ 5e7eb0e3903f._

--- a/docs/runbooks/pr-previews.md
+++ b/docs/runbooks/pr-previews.md
@@ -31,3 +31,5 @@
 - Reintroduce legacy hosts, raw Render hooks, non-amd64 images, or per-workspace installs.
 
 
+
+> Note: `/api/version` on Vercel previews may return **401** (protection). Validate required runtime headers via the **staging API**: `https://cerply-api-staging-latest.onrender.com/api/version`.

--- a/docs/specs/cerply-technical-spec.md
+++ b/docs/specs/cerply-technical-spec.md
@@ -1,0 +1,77 @@
+# Cerply — Technical Requirements (Tech Spec)
+Version: v1.2
+Status: AUTHORITATIVE — single source of truth for technical requirements
+Owner: Engineering (Robert + lead dev)
+Changelog: see History section at bottom
+
+SSOT: This document is the authoritative source for technical requirements and must link back to BRD IDs for business value.
+
+## 1) System Overview
+- API: Fastify (Node 20) on Render; envs: staging & prod.
+- DB: Postgres (Render) with Drizzle migrations & seed.
+- Web: Next.js; /api/:path* proxies to API_ORIGIN/api/:path*.
+- Containers: single Dockerfile (amd64); GHCR tags: staging, staging-latest, prod.
+
+## 2) Reliability & Deployments
+- /api/version must return headers: x-image-tag, x-image-revision, x-image-created, x-runtime-channel.
+- CI/CD:
+  - ci.yml: build/test/typecheck -> build+push image -> staging deploy -> header asserts.
+  - promote-prod.yml: tag promote -> Render deploy -> health wait.
+  - Nightly smoke & header checks.
+- PR previews: label-gated workflow on Vercel; sticky URL; soft-fail 429; teardown; 48h sweep. Legacy deploy gated and runs vercel pull + build + --prebuilt in web/.
+
+## 3) Certified Pipeline (Maps to BRD B4)
+- Planner (LLM-A): scope/structure.
+- Proposers (LLM-B, LLM-C): two independent drafts.
+- Checker (LLM-D): verify claims against citations (must be real/credible); produce diffs & verdict.
+- Convergence: select/merge; lock content + metadata (source URIs, agent prompts/outputs, checksums).
+- Storage: persist prompts, outputs, diffs, reviewer stamp (for Industry Certified), timestamps.
+- Flags: feature flag supports provider/model swaps (OpenAI/Google/Anthropic), temperatures, retries, fallbacks.
+- Cost ledger: per-call cost capture.
+
+## 4) Adaptive Learning (Maps to BRD B2)
+- Signals: accuracy, latency, hint usage, item difficulty, user prefs (format, length).
+- Policy: per-user plan that adjusts item order, difficulty, and review cadence (Leitner-style acceptable for MVP).
+- Controls: admin knobs for floor/ceiling difficulty; user preferred formats.
+- Telemetry: events for schedule changes and outcomes.
+
+## 5) Group Learning (Maps to BRD B3)
+- Push: author selects topic/set -> push to group (team/family/friends).
+- Tracking: group dashboard: participation, completion, accuracy.
+- Privacy: org mode keeps PII inside tenant; consumer groups default minimal profile.
+- APIs: /groups, /groups/:id/members, /groups/:id/push, /groups/:id/stats (scoped by auth).
+
+## 6) Access & Pricing (Maps to BRD B6)
+- Free consumer tier: limit concurrent topics; block Certified access at API/authz.
+- Certified access: entitlements for subscription and pay-as-you-go.
+- Gates: UI hides locked content; API enforces.
+
+## 7) Telemetry & Observability (Maps to BRD B9)
+- Event stream: plan_generated, item_attempted, review_scheduled, exported, certified_locked, group_push.
+- Dashboards/exports for ops & GTM.
+
+## 8) Security & Limits
+- Basic auth (passwordless or simple session), per-IP/user rate limits, request logging (PII-guarded).
+- Secrets via GitHub/Render; none in repo.
+- No raw deploy hooks; no legacy hosts; no per-workspace lockfiles; amd64 only.
+
+## 9) Mobile Readiness (BRD B7)
+- REST/Graph API stable for iOS/Android; mobile apps deferred; enterprise variant honors SSO/MAM policies later.
+
+## 10) BRD <-> Tech Mapping (Crosswalk)
+- B2 Adaptive <-> T4 Adaptive
+- B3 Group <-> T5 Group
+- B4 Certified <-> T3 Pipeline
+- B5 Export/Share <-> T2/Integrations
+- B6 Access/Pricing <-> T6 Access
+- B8 Ops <-> T2 Deployments
+- B9 Metrics <-> T7 Telemetry
+
+## 11) Acceptance & Health
+- /api/health 200 JSON; /api/db/health 200 or 5xx JSON (never 404); __routes.json lists both.
+- Smokes verify headers & health; web smoke respects api_base; retries & timeouts set.
+
+---
+
+## History
+- v1.2 (2025-09-19): Consolidated Tech Spec; added certification pipeline details, adaptive/group modules, access gates, BRD<->Tech crosswalk, mobile readiness.


### PR DESCRIPTION
- BRD IDs: — (governance), maps to multiple items\n- Tech sections: Overview, Deployments, Crosswalk\n- Business value: Single source of truth and governance linkages.\n- Acceptance: Docs present; PR template updated; reconciliation table added.\nThis PR adds:\n- docs/brd/cerply-brd.md\n- docs/specs/cerply-technical-spec.md\n- docs/guide/cerply-gpt-instructions.md\n- .github/pull_request_template.md (enforces BRD IDs + Tech sections)\n- docs/status/reconciliation.md\nFunctional spec is stubbed to point at the Tech Spec; legacy Project Instruction.docx archived if present.