### PR TITLE
chore(ssot): add CODEOWNERS and SSOT nudge workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# SSOT ownership
+# Business Requirements
+/docs/brd/** @robnreb1
+# Technical Specifications
+/docs/specs/** @robnreb1 @lead-dev-handle

--- a/.github/workflows/ssot-lint.yml
+++ b/.github/workflows/ssot-lint.yml
@@ -1,27 +1,57 @@
 name: ssot-lint
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
-  workflow_dispatch: {}
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to nudge (optional)"
+        required: false
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 jobs:
   nudge:
     runs-on: ubuntu-latest
     steps:
       - name: Nudge if BRD/Tech fields are empty
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
-            const body = (context.payload.pull_request && context.payload.pull_request.body) || "";
-            const missing = [];
-            if (!/BRD IDs:\s*\S+/i.test(body)) missing.push("BRD IDs");
-            if (!/Tech sections:\s*\S+/i.test(body)) missing.push("Tech sections");
-            if (missing.length === 0) { core.info("All SSOT fields present."); return; }
-            const marker = "[ssot-lint]";
-            const comments = await github.paginate(github.rest.issues.listComments, { owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, per_page: 100 });
-            const already = comments.some(c => c.user && c.user.type === "Bot" && c.body && c.body.includes(marker));
-            if (!already) {
-              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body: marker + " Thanks for the PR! For SSOT governance, please fill in: " + missing.join(", ") + " in the PR description under the template fields (BRD IDs:, Tech sections:). This is a gentle nudge and does not block merging." });
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            async function findPrNumber() {
+              if (context.eventName === 'pull_request' && context.payload.pull_request) {
+                return context.payload.pull_request.number;
+              }
+              const inputPr = core.getInput('pr') || '';
+              if (inputPr) return parseInt(inputPr, 10);
+
+              const refName = (context.ref || '').replace(/^refs\/heads\//, '');
+              if (!refName) return null;
+              const { data } = await github.rest.pulls.list({ owner, repo, state: 'open', head: `${owner}:${refName}`, per_page: 1 });
+              return (data && data.length) ? data[0].number : null;
             }
+
+            const prNumber = await findPrNumber();
+            if (!prNumber) { core.info('No PR context found (branch run with no open PR). Exiting 0.'); return; }
+
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            const body = (pr.body || '').trim();
+
+            const missing = [];
+            if (!/BRD IDs:\s*\S+/i.test(body)) missing.push('BRD IDs');
+            if (!/Tech sections:\s*\S+/i.test(body)) missing.push('Tech sections');
+
+            if (missing.length === 0) { core.info('All SSOT fields present. No comment needed.'); return; }
+
+            const marker = '[ssot-lint]';
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: prNumber, per_page: 100 });
+            const already = comments.some(c => c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker));
+            if (already) { core.info('Nudge already posted; skipping.'); return; }
+
+            const msg = `${marker} Thanks! Please fill in: ${missing.join(', ')} in the PR description under the template fields (BRD IDs:, Tech sections:). This is a gentle nudge and does not block merging.`;
+            await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body: msg });

--- a/.github/workflows/ssot-lint.yml
+++ b/.github/workflows/ssot-lint.yml
@@ -1,0 +1,26 @@
+name: ssot-lint
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  nudge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Nudge if BRD/Tech fields are empty
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = (context.payload.pull_request && context.payload.pull_request.body) || "";
+            function isFilled(label) { const re = new RegExp(label + ":\\s*\\S+", "i"); return re.test(body); }
+            const missing = [];
+            if (!isFilled("BRD IDs")) missing.push("BRD IDs");
+            if (!isFilled("Tech sections")) missing.push("Tech sections");
+            if (missing.length === 0) { core.info("All SSOT fields present."); return; }
+            const marker = "[ssot-lint]";
+            const comments = await github.paginate(github.rest.issues.listComments, { owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, per_page: 50 });
+            const already = comments.some(c => c.user && c.user.type === "Bot" && c.body && c.body.includes(marker));
+            if (already) { core.info("Nudge already posted; skipping."); return; }
+            await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body: marker + " Thanks for the PR! For SSOT governance, please fill in: " + missing.join(", ") + " in the PR description under the template fields (BRD IDs:, Tech sections:). This is a gentle nudge and does not block merging." });

--- a/.github/workflows/ssot-lint.yml
+++ b/.github/workflows/ssot-lint.yml
@@ -2,6 +2,7 @@ name: ssot-lint
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  workflow_dispatch: {}
 permissions:
   contents: read
   pull-requests: write
@@ -14,13 +15,13 @@ jobs:
         with:
           script: |
             const body = (context.payload.pull_request && context.payload.pull_request.body) || "";
-            function isFilled(label) { const re = new RegExp(label + ":\\s*\\S+", "i"); return re.test(body); }
             const missing = [];
-            if (!isFilled("BRD IDs")) missing.push("BRD IDs");
-            if (!isFilled("Tech sections")) missing.push("Tech sections");
+            if (!/BRD IDs:\s*\S+/i.test(body)) missing.push("BRD IDs");
+            if (!/Tech sections:\s*\S+/i.test(body)) missing.push("Tech sections");
             if (missing.length === 0) { core.info("All SSOT fields present."); return; }
             const marker = "[ssot-lint]";
-            const comments = await github.paginate(github.rest.issues.listComments, { owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, per_page: 50 });
+            const comments = await github.paginate(github.rest.issues.listComments, { owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, per_page: 100 });
             const already = comments.some(c => c.user && c.user.type === "Bot" && c.body && c.body.includes(marker));
-            if (already) { core.info("Nudge already posted; skipping."); return; }
-            await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body: marker + " Thanks for the PR! For SSOT governance, please fill in: " + missing.join(", ") + " in the PR description under the template fields (BRD IDs:, Tech sections:). This is a gentle nudge and does not block merging." });
+            if (!already) {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body: marker + " Thanks for the PR! For SSOT governance, please fill in: " + missing.join(", ") + " in the PR description under the template fields (BRD IDs:, Tech sections:). This is a gentle nudge and does not block merging." });
+            }


### PR DESCRIPTION
Adds CODEOWNERS for BRD and Tech specs and a non-blocking PR nudge commenting if BRD IDs or Tech sections are empty in the PR description.