### PR TITLE
governance: add Epic issue template with SSOT fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,34 @@
+name: Epic
+description: Track a large, outcome-focused body of work
+labels: ["Epic"]
+body:
+  - type: input
+    id: brd
+    attributes:
+      label: BRD IDs
+      description: e.g., B2, B4
+      placeholder: "B2, B4"
+    validations:
+      required: true
+  - type: input
+    id: tech
+    attributes:
+      label: Tech sections
+      description: e.g., T3.1, T5
+      placeholder: "T3.1, T5"
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: What changes for users/business?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: Clear, testable checks
+    validations:
+      required: true


### PR DESCRIPTION
Adds .github/ISSUE_TEMPLATE/epic.yml requiring BRD IDs, Tech sections, Outcome, and Acceptance, and auto-labels Epic. Disables blank issues.