### PR TITLE
feat(certified): stub contract + CORS + preview (refs #82)

### DIFF
--- a/api/tests/certified.test.ts
+++ b/api/tests/certified.test.ts
@@ -34,8 +34,20 @@ describe('Certified endpoints (feature-flagged stubs)', () => {
     const r = await app.inject({ method: 'POST', url: '/api/certified/plan' });
     expect([501]).toContain(r.statusCode);
     const j = r.json();
-    expect(j?.error?.code).toBe('NOT_IMPLEMENTED');
-    expect(j?.error?.details?.step).toBe('plan');
+    expect(j?.status).toBe('stub');
+    expect(j?.endpoint).toBe('certified.plan');
+    expect(typeof j?.request_id).toBe('string');
+    expect(j?.request_id.length).toBeGreaterThan(0);
+    expect(j?.enabled).toBe(true);
+    expect(j?.message).toMatch(/enabled but not implemented/i);
+  });
+
+  it('OPTIONS preflight returns 204 with CORS headers', async () => {
+    const r = await app.inject({ method: 'OPTIONS', url: '/api/certified/plan' });
+    expect(r.statusCode).toBe(204);
+    expect(r.headers['access-control-allow-origin']).toBe('*');
+    expect(r.headers['access-control-allow-methods']).toMatch(/POST/);
+    expect(r.headers['access-control-allow-headers']).toMatch(/authorization/i);
   });
 
   it('expert module approve requires admin', async () => {

--- a/docs/spec/flags.md
+++ b/docs/spec/flags.md
@@ -7,6 +7,21 @@
 - ff_marketplace_ledgers_v1
 - ff_benchmarks_optin_v1
  
+Runtime (simple gate)
+- CERTIFIED_ENABLED (default: false) — enables `/api/certified/*` stub routes
+  - When true, `POST /api/certified/plan` returns 501 with JSON:
+    {
+      "status":"stub",
+      "endpoint":"certified.plan",
+      "request_id":"<uuid-v4>",
+      "enabled": true,
+      "message":"Certified pipeline is enabled but not implemented yet."
+    }
+  - CORS preflight `OPTIONS /api/certified/*` returns 204 with headers:
+    - access-control-allow-origin: *
+    - access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+    - access-control-allow-headers: content-type, authorization
+ 
 Env (observability)
 - OBS_SAMPLE_PCT (0..100) — % of requests sampled as events(type='latency')
 - BUDGET_DAILY_CENTS — enables /api/ledger/alarm 24h budget check

--- a/docs/spec/use-cases.md
+++ b/docs/spec/use-cases.md
@@ -3,4 +3,17 @@
 - Curator: import (url/file/transcript), chunk, generate, quality score — MVP ✅
 - Trust: evidence/coverage snapshot — stub ✅
 
+- Certified: pipeline scaffold — flagged stubs ✅
+  - Given CERTIFIED_ENABLED=false, POST `/api/certified/plan` → 503 `{ error: { code: 'CERTIFIED_DISABLED', ... } }`
+  - Given CERTIFIED_ENABLED=true, same route → 501 stub JSON:
+    {
+      "status":"stub",
+      "endpoint":"certified.plan",
+      "request_id":"<uuid-v4>",
+      "enabled": true,
+      "message":"Certified pipeline is enabled but not implemented yet."
+    }
+  - Preview page: `web/app/(preview)/certified/page.tsx` — shows stub response when `NEXT_PUBLIC_PREVIEW_CERTIFIED_UI=true`.
+  - Drizzle migrations apply cleanly; server boots
+
 Add new cases here as bullets with steps + acceptance criteria.

--- a/web/app/(preview)/certified/page.tsx
+++ b/web/app/(preview)/certified/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { useState } from 'react';
+import { apiBase } from '../../../lib/apiBase';
+
+export default function CertifiedPreviewPage() {
+  if (process.env.NEXT_PUBLIC_PREVIEW_CERTIFIED_UI !== 'true') {
+    return (
+      <div style={{ padding: 16 }}>
+        <h1 style={{ fontSize: 18, fontWeight: 600 }}>Certified Preview</h1>
+        <p>Preview disabled. Set NEXT_PUBLIC_PREVIEW_CERTIFIED_UI=true to enable.</p>
+      </div>
+    );
+  }
+
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<number | null>(null);
+  const [json, setJson] = useState<any>(null);
+
+  async function callPlan() {
+    setLoading(true);
+    setStatus(null);
+    setJson(null);
+    try {
+      const res = await fetch(`${apiBase()}/api/certified/plan`, { method: 'POST' });
+      setStatus(res.status);
+      const data = await res.json().catch(() => ({}));
+      setJson(data);
+    } catch (e) {
+      setStatus(-1);
+      setJson({ error: String((e as any)?.message || e) });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div style={{ padding: 16, display: 'grid', gap: 12 }}>
+      <h1 style={{ fontSize: 18, fontWeight: 600 }}>Certified Preview</h1>
+      <button onClick={callPlan} disabled={loading} style={{ padding: '8px 12px', border: '1px solid #ccc', borderRadius: 8 }}>
+        {loading ? 'Calling…' : 'POST /api/certified/plan'}
+      </button>
+      {status !== null && (
+        <div>
+          <div style={{ marginBottom: 8 }}>Status: <strong>{status}</strong></div>
+          {json && (
+            <pre style={{ background: '#0b0b0b', color: '#d5f5e3', padding: 12, borderRadius: 8, overflowX: 'auto' }}>
+{JSON.stringify(json, null, 2)}
+            </pre>
+          )}
+          {json?.request_id && (
+            <div style={{ marginTop: 8 }}>request_id: <code style={{ background: '#fff3cd', padding: '2px 6px', borderRadius: 6 }}>{json.request_id}</code></div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+

--- a/web/scripts/smoke-api.mjs
+++ b/web/scripts/smoke-api.mjs
@@ -59,6 +59,27 @@ async function fetchJson(url, attempt = 1) {
 
   const picked = Object.fromEntries(REQUIRED.map((h) => [h, headers[h]]));
   console.log('SMOKE OK:', { version: body, headers: picked });
+  
+  // Cerply Certified stub check (non-fatal; expect 501 or 503)
+  try {
+    const resp = await fetch(`${API_BASE}/api/certified/plan`, { method: 'POST', signal: AbortSignal.timeout(TIMEOUT_MS) });
+    const code = resp.status;
+    console.log(`[certified] /api/certified/plan -> ${code}`);
+    if (![501,503].includes(code)) {
+      console.warn(`WARN: expected 501/503 from /api/certified/plan, got ${code}`);
+    }
+    if (code === 501) {
+      const j = await resp.json().catch(() => ({}));
+      const ok = j && j.status === 'stub' && typeof j.request_id === 'string' && j.request_id.length > 0;
+      if (!ok) {
+        console.warn('WARN: 501 body missing status:"stub" or non-empty request_id');
+      } else {
+        console.log(`[certified] stub ok request_id=${j.request_id}`);
+      }
+    }
+  } catch (e) {
+    console.log('(certified stub check skipped)', e?.message || e);
+  }
 })().catch((e) => {
   console.error('* SMOKE ERROR', e);
   process.exit(1);


### PR DESCRIPTION
EPIC: #82  
This PR locks the Certified stub contract and CORS behavior and adds a minimal web preview.
- API: POST /api/certified/plan — 501 with:
  { "status":"stub", "endpoint":"certified.plan", "request_id":"<uuid>", "enabled": true, "message":"Certified pipeline is enabled but not implemented yet." }
- CORS: OPTIONS /api/certified/* — 204 with ACAO:*; methods GET,HEAD,PUT,PATCH,POST,DELETE; headers content-type, authorization.
- Web: /certified preview page (guarded by NEXT_PUBLIC_PREVIEW_CERTIFIED_UI).
- Smoke/tests/docs updated.
SSOT: BRD B4 • Tech T3. No prod flow changes.

Acceptance
- [ ] POST /api/certified/plan → 501 with keys above + non-empty request_id
- [ ] OPTIONS /api/certified/plan → 204 with required CORS headers
- [ ] Preview page shows stub when NEXT_PUBLIC_PREVIEW_CERTIFIED_UI=true
- [ ] CI green; smoke accepts 501
