### PR TITLE
fix(certified): preflight 204 for /api/certified/* (EPIC #82)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -128,6 +128,21 @@ function deterministicGenerateStub() {
 export async function createApp() {
   // --- App bootstrap ---
   const app = Fastify({ logger: true });
+  // Explicit CORS preflight for Certified endpoints so tests and browsers see 204 with headers
+  app.addHook('onRequest', async (req: any, reply: any) => {
+    try {
+      const method = String(req?.method || '').toUpperCase();
+      const url = String(req?.url || '');
+      if (method === 'OPTIONS' && url.startsWith('/api/certified/')) {
+        reply
+          .header('access-control-allow-origin', '*')
+          .header('access-control-allow-methods', 'GET,HEAD,PUT,PATCH,POST,DELETE')
+          .header('access-control-allow-headers', 'content-type, authorization')
+          .code(204)
+          .send();
+      }
+    } catch {}
+  });
   
   // ── Observability: per-request duration headers + optional DB sampling ──
   const OBS_PCT = Number(process.env.OBS_SAMPLE_PCT || '0'); // 0..100


### PR DESCRIPTION
Adds an early onRequest CORS preflight handler for /api/certified/* so CI test 'OPTIONS preflight returns 204' passes. Minimal change. (EPIC #82)