### PR TITLE
ci: gate vercel prod on manual input (EPIC #82)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,10 @@ jobs:
   vercel-prod:
     if: >
       (github.ref == 'refs/heads/main') &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      (
+        (github.event_name == 'push' && (github.event.inputs.deploy_prod != 'true')) ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_prod == 'true')
+      )
     name: Vercel Production (main/manual)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,8 +274,9 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/cerply-api
           tags: |
             type=sha,format=long
-            type=raw,value=staging,enable=${{ github.ref == 'refs/heads/staging' }}
-            type=raw,value=staging-latest,enable=${{ github.ref == 'refs/heads/staging' }}
+            # Tag staging and staging-latest on both staging and main to keep Render staging current
+            type=raw,value=staging,enable=${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' }}
+            type=raw,value=staging-latest,enable=${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' }}
             # On main, publish prod-candidate and a short sha tag for promotion
             type=raw,value=prod-candidate,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,format=short,prefix=sha-,enable=${{ github.ref == 'refs/heads/main' }}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -128,6 +128,21 @@ function deterministicGenerateStub() {
 export async function createApp() {
   // --- App bootstrap ---
   const app = Fastify({ logger: true });
+  // Explicit CORS preflight for Certified endpoints so tests and browsers see 204 with headers
+  app.addHook('onRequest', async (req: any, reply: any) => {
+    try {
+      const method = String(req?.method || '').toUpperCase();
+      const url = String(req?.url || '');
+      if (method === 'OPTIONS' && url.startsWith('/api/certified/')) {
+        reply
+          .header('access-control-allow-origin', '*')
+          .header('access-control-allow-methods', 'GET,HEAD,PUT,PATCH,POST,DELETE')
+          .header('access-control-allow-headers', 'content-type, authorization')
+          .code(204)
+          .send();
+      }
+    } catch {}
+  });
   
   // ── Observability: per-request duration headers + optional DB sampling ──
   const OBS_PCT = Number(process.env.OBS_SAMPLE_PCT || '0'); // 0..100


### PR DESCRIPTION
Avoid auto prod deploy on CI dispatch; run only when workflow_dispatch input deploy_prod=true. Also keeps staging-latest tagging on main.