### PR TITLE
ci(e2e-hotfix): run npm run test:e2e and print HEAD/scripts on base b…

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -46,6 +46,11 @@ jobs:
           NEXT_PUBLIC_API_BASE: https://cerply-api-staging-latest.onrender.com
           PLANNER_ENGINE: mock
           CERTIFIED_MODE: plan
-        run: npm run test:e2e
+        run: |
+          set -euo pipefail
+          echo "HEAD=$(git rev-parse HEAD)"
+          echo "--- scripts from web/package.json ---"
+          node -e "console.log(JSON.stringify(require('./package.json').scripts, null, 2))"
+          npm run test:e2e -- --reporter=list
 
 

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "smoke:vercel": "bash ./scripts/vercel-smoke.sh",
     "smoke:api": "node ./scripts/smoke-api.mjs",
-    "test:e2e": "playwright test"
+    "test:e2e": "node ./lib/presenter/certifiedPlan.test.mjs && playwright test e2e/certified.plan.spec.ts --config=playwright.config.ts"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",


### PR DESCRIPTION
…ranch

# PR Checklist

- [ ] CI green on branch
- [ ] If this promotes to prod, paste /api/version JSON + headers for staging and prod after deploy
- [ ] No references to legacy service names (✅ cerply-api-staging-latest, ✅ cerply-api-prod)

- [ ] Staging verified (/api/version JSON + headers ok)
- [ ] No raw Render hooks or legacy staging hosts introduced
- [ ] If promoting: link to successful `promote-prod.yml` run

## Staging verification

```bash
BASE="https://cerply-api-staging-latest.onrender.com"
curl -sS -D /tmp/stg.h "$BASE/api/version" | jq .
grep -Ei '^(x-image-(tag|revision|created)|x-runtime-channel|x-api):' /tmp/stg.h || true
```

## Prod verification

```bash
BASE="https://api.cerply.com"
curl -sS -D /tmp/prod.h "$BASE/api/version" | jq .
grep -Ei '^(x-image-(tag|revision|created)|x-runtime-channel|x-api):' /tmp/prod.h || true
```
