### PR TITLE
chore(docs): record staging CORS verification for certified plan [preview]

### DIFF
--- a/progress/OVERNIGHT_LOG.md
+++ b/progress/OVERNIGHT_LOG.md
@@ -53,3 +53,6 @@
 
 2025-09-24T20:51:45Z - P1 start: citations rigor + audit trail + web preview
 
+
+2025-09-25T05:32:45Z - start CORS verification (staging) for /api/certified/plan; will attach header blocks to PR
+

--- a/progress/OVERNIGHT_LOG.md
+++ b/progress/OVERNIGHT_LOG.md
@@ -56,3 +56,4 @@
 
 2025-09-25T05:32:45Z - start CORS verification (staging) for /api/certified/plan; will attach header blocks to PR
 
+2025-09-25T05:35:54Z - CORS verification PR #145 opened; verdict=green

--- a/progress/STATE.json
+++ b/progress/STATE.json
@@ -1,6 +1,7 @@
 {
-  "step": "open-pr",
-  "status": "updated",
-  "branch": "feat/certified-multiproposer-checker-lock-p0",
-  "lastUpdated": "2025-09-24T19:58:40Z"
+  "epic": 82,
+  "action": "staging-cors-verified",
+  "route": "/api/certified/plan",
+  "verdict": "pending",
+  "timestamp": "2025-09-25T05:32:45Z"
 }

--- a/progress/STATE.json
+++ b/progress/STATE.json
@@ -2,6 +2,7 @@
   "epic": 82,
   "action": "staging-cors-verified",
   "route": "/api/certified/plan",
-  "verdict": "pending",
-  "timestamp": "2025-09-25T05:32:45Z"
+  "verdict": "green",
+  "timestamp": "2025-09-25T05:36:37Z",
+  "pr": 145
 }


### PR DESCRIPTION
This PR records a staging CORS verification for `/api/certified/plan` and ties it back to the BRD/FSD and Epic #82.

References:
- BRD: `docs/brd/cerply-brd.md` (B4 Certified Pipeline)
- FSD: `docs/certified/PLAN_MODE.md` and `docs/certified/OPENAPI.md` (CORS invariants)
- Epic #82: Certified pipeline (planner→2 proposers→checker→lock)

Checklist:
- [x] OPTIONS → 204 + `access-control-allow-origin: *`
- [x] POST → includes `access-control-allow-origin: *`
- [x] POST → does NOT include `access-control-allow-credentials: true`
- [x] POST → does NOT include `x-cors-certified-hook`

Headers are posted as a PR comment for auditability.
