### PR TITLE
feat(orchestrator): v0 lifecycle (status/logs/cancel) — EPIC #59

### DIFF
--- a/.github/workflows/ci-orchestrator.yml
+++ b/.github/workflows/ci-orchestrator.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main ]
   push:
-    branches: [ feat/orchestrator-v0-preview ]
+    branches: [ feat/orchestrator-v0-preview, feat/orchestrator-v0-lifecycle ]
 
 jobs:
   api-unit:
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: '20' }
       - run: npm ci
-      - name: Orchestrator CORS Canary (staging)
+      - name: Orchestrator Canary (staging)
         env:
           API_BASE: https://cerply-api-staging-latest.onrender.com
         run: node scripts/smoke-api.mjs

--- a/api/.data/analytics.ndjson
+++ b/api/.data/analytics.ndjson
@@ -11,3 +11,6 @@
 {"event":"plan_request","ts":"2025-09-25T05:46:40.882Z","anon_session_id":"s1","context":{"topic":"Hashes","engine":"mock"}}
 {"event":"plan_request","ts":"2025-09-26T09:05:21.817Z","anon_session_id":"s1","context":{"topic":"Hashes","engine":"mock"}}
 {"event":"plan_request","ts":"2025-09-26T09:12:29.668Z","anon_session_id":"s1","context":{"topic":"Hashes","engine":"mock"}}
+{"event":"plan_request","ts":"2025-09-26T19:37:20.793Z","anon_session_id":"s1","context":{"topic":"Hashes","engine":"mock"}}
+{"event":"plan_request","ts":"2025-09-26T19:38:59.946Z","anon_session_id":"s1","context":{"topic":"Hashes","engine":"mock"}}
+{"event":"plan_request","ts":"2025-09-26T19:40:28.465Z","anon_session_id":"s1","context":{"topic":"Hashes","engine":"mock"}}

--- a/api/tests/orchestrator.lifecycle.test.ts
+++ b/api/tests/orchestrator.lifecycle.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import createApp from '../src/index';
+
+describe('Orchestrator lifecycle (status/logs/cancel)', () => {
+  let app: Awaited<ReturnType<typeof createApp>>;
+
+  beforeAll(async () => {
+    vi.stubEnv('ORCH_ENABLED', 'true');
+    vi.stubEnv('ORCH_MODE', 'mock');
+    app = await createApp();
+  });
+  afterAll(async () => { await app.close(); vi.unstubAllEnvs(); });
+
+  it('logs endpoint returns recent lines including job.end', async () => {
+    const payload = { goal: 'log-demo', steps: [], limits: { maxSteps: 2, maxWallMs: 1000 } };
+    const r = await app.inject({ method: 'POST', url: '/api/orchestrator/jobs', headers: { 'content-type': 'application/json' }, payload });
+    expect(r.statusCode).toBe(200);
+    const { job_id } = r.json() as any;
+
+    // poll until terminal
+    let status = 'queued';
+    const t0 = Date.now();
+    while (Date.now() - t0 < 3000 && status !== 'succeeded' && status !== 'failed') {
+      const s = await app.inject({ method: 'GET', url: `/api/orchestrator/jobs/${job_id}` });
+      expect([200, 404]).toContain(s.statusCode);
+      if (s.statusCode === 200) status = (s.json() as any).status;
+      await new Promise(res => setTimeout(res, 25));
+    }
+    expect(['succeeded','failed']).toContain(status);
+
+    const lg = await app.inject({ method: 'GET', url: `/api/orchestrator/jobs/${job_id}/logs?n=20` });
+    expect(lg.statusCode).toBe(200);
+    const body = lg.json() as any;
+    expect(Array.isArray(body.logs)).toBe(true);
+    const last = body.logs[body.logs.length - 1];
+    expect(last?.msg).toBe('job.end');
+  });
+
+  it('cancel transitions running job to canceled', async () => {
+    const payload = { goal: 'cancel-demo', steps: [{ type: 'dev.log' }, { type: 'dev.log' }, { type: 'dev.log' }], limits: { maxSteps: 10, maxWallMs: 2000 } };
+    const r = await app.inject({ method: 'POST', url: '/api/orchestrator/jobs', headers: { 'content-type': 'application/json' }, payload });
+    expect(r.statusCode).toBe(200);
+    const { job_id } = r.json() as any;
+
+    // wait until running if possible, then cancel
+    let status = 'queued';
+    const t0 = Date.now();
+    while (Date.now() - t0 < 1000 && status !== 'running') {
+      const s = await app.inject({ method: 'GET', url: `/api/orchestrator/jobs/${job_id}` });
+      if (s.statusCode === 200) status = (s.json() as any).status;
+      await new Promise(res => setTimeout(res, 25));
+    }
+    await app.inject({ method: 'POST', url: `/api/orchestrator/jobs/${job_id}/cancel` });
+
+    // poll for canceled or any terminal
+    const t1 = Date.now();
+    let final = status;
+    while (Date.now() - t1 < 3000 && !['canceled','succeeded','failed'].includes(final)) {
+      const s = await app.inject({ method: 'GET', url: `/api/orchestrator/jobs/${job_id}` });
+      if (s.statusCode === 200) final = (s.json() as any).status;
+      await new Promise(res => setTimeout(res, 25));
+    }
+    expect(['canceled','succeeded','failed']).toContain(final);
+  });
+});
+
+

--- a/api/tests/orchestrator.route.test.ts
+++ b/api/tests/orchestrator.route.test.ts
@@ -39,7 +39,7 @@ describe('Orchestrator routes (preview)', () => {
     // poll status until finished (with small timeout)
     let status = 'queued';
     const t0 = Date.now();
-    while (Date.now() - t0 < 3000 && status !== 'finished' && status !== 'failed') {
+    while (Date.now() - t0 < 3000 && status !== 'succeeded' && status !== 'failed') {
       const s = await app.inject({ method: 'GET', url: `/api/orchestrator/jobs/${job_id}` });
       expect([200,404]).toContain(s.statusCode);
       if (s.statusCode === 200) {
@@ -48,7 +48,7 @@ describe('Orchestrator routes (preview)', () => {
       }
       await new Promise(res => setTimeout(res, 50));
     }
-    expect(['finished','failed']).toContain(status);
+    expect(['succeeded','failed']).toContain(status);
   });
 });
 

--- a/docs/orchestrator/V0.md
+++ b/docs/orchestrator/V0.md
@@ -34,15 +34,20 @@ The Orchestrator runs task jobs through simple steps with safety limits. v0 uses
 
 ## Endpoints
 
-- POST `/api/orchestrator/jobs` → `{ job_id }` on valid JSON.
-- GET `/api/orchestrator/jobs/:id` → `{ job_id, status, started_at?, finished_at?, error?, stepsRun }`.
+- POST `/api/orchestrator/jobs` → `{ job_id }` on valid JSON. Accepts camelCase limits; snake_case (`max_steps`, `max_wall_ms`, `max_tokens`) is normalized.
+- GET `/api/orchestrator/jobs/:id` → `{ job_id, status, started_at?, finished_at?, error?, stepsRun }` with status in `queued|running|succeeded|failed|canceled`.
+- GET `/api/orchestrator/jobs/:id/logs` (preview) → `{ job_id, logs: [{ t, level, msg, data? }] }` (recent N via `?n=`; default 50).
+- POST `/api/orchestrator/jobs/:id/cancel` → `{ ok: true }` (idempotent; transitions running job to `canceled`).
 - GET `/api/orchestrator/events?job=:id` (SSE) → `event: start|step.start|step.ok|step.retry|step.error|end`.
 
 ## Engine v0
 
 - In-memory FIFO queue.
-- Loop-guard: enforces `limits.maxSteps` and `limits.maxWallMs`.
+- Loop-guard: enforces `limits.maxSteps` and `limits.maxWallMs` (default 10s when omitted).
 - Retry with jittered backoff (max 2 retries per step).
+
+### Redis (optional)
+- When `ORCH_BACKEND=redis` and `REDIS_URL` are set, a Redis-backed queue may be used (MVP keeps interface identical; in-memory is default).
 
 ## Workers (Adapters) v0
 
@@ -62,6 +67,11 @@ The Orchestrator runs task jobs through simple steps with safety limits. v0 uses
 curl -sS -X POST "$API_BASE/api/orchestrator/jobs" \
   -H 'content-type: application/json' \
   -d '{"goal":"hello","steps":[],"limits":{"maxSteps":3,"maxWallMs":2000}}'
+
+# snake_case limits accepted
+curl -sS -X POST "$API_BASE/api/orchestrator/jobs" \
+  -H 'content-type: application/json' \
+  -d '{"goal":"hello","steps":[],"limits":{"max_steps":3,"max_wall_ms":2000}}'
 
 curl -sS "$API_BASE/api/orchestrator/events?job=$JOB_ID"
 ```


### PR DESCRIPTION
Implements orchestrator v0 lifecycle:\n- Endpoints: POST /jobs; GET /jobs/:id; GET /jobs/:id/logs (preview); POST /jobs/:id/cancel\n- Engine: in-memory durable queue, default maxWallMs=10s, cancellation, logs ring buffer\n- Security: CORS invariants via orchestrator plugin (ACAO:*; no ACAC), OPTIONS 204\n- Validation: snake_case limits normalized to camelCase before Zod parse\n- Tests: route + lifecycle tests; headers on error paths\n- Docs: V0.md updated; FSD to follow-up\n\nBRD §Orchestrator; FSD §Orchestrator v0.\n