### PR TITLE
fix(web): remove hardcoded API rewrites from vercel.json

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -6,11 +6,7 @@
       "headers": [{ "key": "x-vercel-json", "value": "loaded" }]
     }
   ],
-  "rewrites": [
-    { "source": "/ping", "destination": "https://httpbin.org/status/204" },
-    { "source": "/api/prompts", "destination": "https://api-stg.cerply.com/prompts" },
-    { "source": "/api/(.*)", "destination": "https://api-stg.cerply.com/api/$1" }
-  ],
+  "rewrites": [],
   "buildCommand": "npm run build",
   "outputDirectory": ".next",
   "installCommand": "npm install",


### PR DESCRIPTION
## 🎯 ROOT CAUSE FOUND!

The **`vercel.json` file had hardcoded rewrites** that were taking precedence over everything else!

```json
"rewrites": [
  { "source": "/api/prompts", "destination": "https://api-stg.cerply.com/prompts" },
  { "source": "/api/(.*)", "destination": "https://api-stg.cerply.com/api/$1" }
]
```

## ❌ The Problem

1. **Vercel rewrites in `vercel.json` happen BEFORE Next.js routing**
2. **The catch-all route handler (`/api/[...path]/route.ts`) was never invoked**
3. **All `/api/*` requests were hardcoded to `api-stg.cerply.com`** (staging, not production!)
4. **The `/api/prompts` rewrite was stripping the `/api` prefix** (destination: `/prompts` instead of `/api/prompts`)

## ✅ The Fix

**Remove all hardcoded rewrites from `vercel.json`** and let the catch-all route handler do its job at runtime with proper environment variables.

## 🧪 Testing

After merge, the M2 proxy should work correctly:
- `GET https://www.cerply.com/api/test-proxy` → Returns debug info with `x-proxied-by` header
- `GET https://www.cerply.com/api/prompts` → Returns prompts list (200 OK)

## 🎉 This Will Finally Fix The Issue!

This was the missing piece - all our previous fixes were correct, but this hardcoded configuration in `vercel.json` was overriding everything!