### PR TITLE
fix(web): add catch-all route to web/app directory

### DIFF
--- a/web/web/app/api/[...path]/route.ts
+++ b/web/web/app/api/[...path]/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest } from 'next/server';
+import { apiRoute } from '@/lib/apiBase';
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+
+function stripHopByHop(headers: Headers) {
+  const out = new Headers(headers);
+  [
+    'host','connection','keep-alive','transfer-encoding','upgrade',
+    'proxy-authenticate','proxy-authorization','te','trailer',
+    'x-forwarded-host','x-vercel-deployment-url'
+  ].forEach(h => out.delete(h));
+  return out;
+}
+
+async function proxy(req: NextRequest, { params }: { params: { path?: string[] } }) {
+  const path = (params.path ?? []).join('/');
+  const src = new URL(req.url);
+  
+  // Test mode: if path is "test-proxy", return debug info instead of proxying
+  if (path === 'test-proxy') {
+    return new Response(JSON.stringify({
+      message: 'Catch-all proxy route is working!',
+      path,
+      NEXT_PUBLIC_API_BASE: process.env.NEXT_PUBLIC_API_BASE,
+      apiRoute: apiRoute(path),
+      timestamp: new Date().toISOString()
+    }), {
+      headers: { 'content-type': 'application/json', 'x-proxied-by': 'next-app-route' }
+    });
+  }
+  
+  const target = `${apiRoute(path)}${src.search}`;
+
+  // Debug logging
+  console.log('[PROXY] path:', path);
+  console.log('[PROXY] target:', target);
+  console.log('[PROXY] NEXT_PUBLIC_API_BASE:', process.env.NEXT_PUBLIC_API_BASE);
+
+  const auth = req.headers.get('authorization') || '';
+  const init: RequestInit = {
+    method: req.method,
+    headers: (() => {
+      const h = stripHopByHop(req.headers);
+      if (auth) h.set('authorization', auth);
+      return h;
+    })(),
+    cache: 'no-store',
+    redirect: 'manual',
+  };
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    init.body = await req.arrayBuffer();
+  }
+
+  const upstream = await fetch(target, init);
+  const headers = stripHopByHop(upstream.headers);
+  headers.set('x-proxied-by', 'next-app-route');
+  headers.set('x-proxy-target', target); // Add target URL to response headers for debugging
+
+  return new Response(upstream.body, { status: upstream.status, headers });
+}
+
+export { proxy as GET, proxy as POST, proxy as PUT, proxy as PATCH, proxy as DELETE, proxy as OPTIONS };


### PR DESCRIPTION
## 🎯 ROOT CAUSE FINALLY FOUND!

The catch-all route `/api/[...path]/route.ts` was in the **root `app/` directory** but Vercel builds from the **`web/` directory**!

## ❌ The Problem

```
app/api/[...path]/route.ts     ← EXISTS (but not deployed by Vercel)
web/app/api/[...path]/route.ts ← MISSING (Vercel needs this!)
```

## Why This Explains Everything

1. **Vercel build logs showed the route**: Next.js found it during local build test
2. **But production returned 404**: File wasn't in the `web/` tree that Vercel deploys
3. **Local tests worked**: We were testing from root `app/`, not `web/app/`

## ✅ The Fix

Copy `app/api/[...path]/route.ts` → `web/app/api/[...path]/route.ts`

Now Vercel will deploy the catch-all route and the M2 proxy will finally work!

## 🧪 Testing

After merge:
```bash
curl https://www.cerply.com/api/test-proxy  # Should return debug JSON with x-proxied-by header
curl https://www.cerply.com/api/prompts      # Should return prompts list (200 OK)
```