### PR TITLE
chore(web): trigger fresh deployment to clear Vercel cache

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -300,3 +300,4 @@ For issues or questions:
 - Run smoke tests with verbose curl output
 - Check Lighthouse report in Chrome DevTools
 
+# Cache test


### PR DESCRIPTION
Trivial change to trigger a fresh Vercel deployment and clear cached 404 responses. Production deployment  has the correct code but Vercel cache is serving old 404s.