### PR TITLE
fix(web): restore functions config to enable serverless routes

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -11,6 +11,14 @@
   "outputDirectory": ".next",
   "installCommand": "npm install",
   "framework": "nextjs",
+  "functions": {
+    "app/api/**/*.ts": {
+      "maxDuration": 30
+    },
+    "pages/api/**/*.js": {
+      "maxDuration": 30
+    }
+  },
   "build": {
     "env": {
       "NEXT_TELEMETRY_DISABLED": "1"


### PR DESCRIPTION
## Problem
Production  routes were returning 404 while staging worked fine.

## Root Cause
PR #185 removed the `functions` configuration from `vercel.json` on the `main` branch, thinking it would help. However, **without this config, Vercel doesn't recognize catch-all routes as serverless functions**.

The `staging` branch still had the `functions` config, which is why staging worked.

## Solution
Restore the `functions` configuration to match what staging has:
```json
"functions": {
  "app/api/**/*.ts": {
    "maxDuration": 30
  },
  "pages/api/**/*.js": {
    "maxDuration": 30
  }
}
```

This tells Vercel to treat TypeScript files in `app/api/` as serverless functions, including catch-all routes like `app/api/[...path]/route.ts`.

## Testing
Once deployed, test:
- `https://www.cerply.com/api/test-proxy` should return JSON (not 404)
- `https://www.cerply.com/api/health` should proxy to backend
- `https://www.cerply.com/api/prompts` should proxy to backend