### PR TITLE
fix(web): add explicit /api/health and /api/prompts routes

### DIFF
--- a/web/app/api/health/route.ts
+++ b/web/app/api/health/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || process.env.NEXT_PUBLIC_API_URL || 'https://api.cerply.com';
+
+export async function GET(req: NextRequest) {
+  const target = `${API_BASE}/api/health`;
+  
+  try {
+    const response = await fetch(target, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      cache: 'no-store',
+    });
+    
+    const data = await response.json();
+    
+    return NextResponse.json(data, {
+      status: response.status,
+      headers: {
+        'x-proxied-by': 'next-explicit-route',
+        'x-proxy-target': target,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Failed to proxy request', target },
+      { status: 502 }
+    );
+  }
+}

--- a/web/app/api/prompts/route.ts
+++ b/web/app/api/prompts/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || process.env.NEXT_PUBLIC_API_URL || 'https://api.cerply.com';
+
+export async function GET(req: NextRequest) {
+  const target = `${API_BASE}/api/prompts`;
+  
+  try {
+    const response = await fetch(target, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      cache: 'no-store',
+    });
+    
+    const data = await response.json();
+    
+    return NextResponse.json(data, {
+      status: response.status,
+      headers: {
+        'x-proxied-by': 'next-explicit-route',
+        'x-proxy-target': target,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Failed to proxy request', target },
+      { status: 502 }
+    );
+  }
+}


### PR DESCRIPTION
## Problem
The catch-all route `app/api/[...path]/route.ts` is being built by Next.js but not matching incoming requests in production. Vercel returns 404 for `/api/health` and `/api/prompts`.

## Solution
Create explicit route files for the critical endpoints:
- `app/api/health/route.ts`
- `app/api/prompts/route.ts`

These will have higher routing priority and will definitely be matched by Next.js.

## Testing
After merge, verify:
```bash
curl -i https://www.cerply.com/api/health
curl -i https://www.cerply.com/api/prompts
```

Both should return 200 with `x-proxied-by: next-explicit-route` header.