### PR TITLE
fix(monitor): install tsx globally for reporter script

### DIFF
--- a/.github/workflows/m3-staging-monitor.yml
+++ b/.github/workflows/m3-staging-monitor.yml
@@ -37,7 +37,9 @@ jobs:
           node-version: '20'
           
       - name: Install dependencies
-        run: npm ci -w api
+        run: |
+          npm ci -w api
+          npm install -g tsx
         
       - name: Run M3 smoke tests against staging
         id: smoke


### PR DESCRIPTION
## Quick Fix

The M3 monitor workflow was failing with `tsx: not found` error.

**Change:** Add `npm install -g tsx` to dependencies step

**Test:** Run #18276188733 failed at reporter step
**Expected:** Next run will succeed

Fixes the "Generate monitor report" step in the M3 Staging Monitor workflow.