### PR TITLE
feat(monitor): add force_fail input for testing auto-issue creation

### DIFF
--- a/.github/workflows/m3-staging-monitor.yml
+++ b/.github/workflows/m3-staging-monitor.yml
@@ -10,6 +10,11 @@ on:
         description: 'Monitor duration in hours'
         required: false
         default: '24'
+      force_fail:
+        description: 'Force failure for testing auto-issue creation'
+        required: false
+        default: 'false'
+        type: boolean
 
 permissions:
   contents: write
@@ -45,15 +50,28 @@ jobs:
         id: smoke
         env:
           API_BASE: https://cerply-api-staging-latest.onrender.com
+          FORCE_FAIL: ${{ inputs.force_fail || 'false' }}
         run: |
           set +e  # Don't fail immediately
           chmod +x api/scripts/smoke-m3.sh
           
-          START_TIME=$(date +%s)
-          ./api/scripts/smoke-m3.sh "$API_BASE" > smoke_output.log 2>&1
-          EXIT_CODE=$?
-          END_TIME=$(date +%s)
-          DURATION=$((END_TIME - START_TIME))
+          # Force failure if requested (for testing alerting)
+          if [ "$FORCE_FAIL" = "true" ]; then
+            echo "🧪 FORCED FAILURE for testing" > smoke_output.log
+            echo "This is an intentional failure to test auto-issue creation" >> smoke_output.log
+            echo "" >> smoke_output.log
+            ./api/scripts/smoke-m3.sh "$API_BASE" >> smoke_output.log 2>&1 || true
+            echo "" >> smoke_output.log
+            echo "--- FORCED FAILURE MARKER ---" >> smoke_output.log
+            EXIT_CODE=2
+            DURATION=1
+          else
+            START_TIME=$(date +%s)
+            ./api/scripts/smoke-m3.sh "$API_BASE" > smoke_output.log 2>&1
+            EXIT_CODE=$?
+            END_TIME=$(date +%s)
+            DURATION=$((END_TIME - START_TIME))
+          fi
           
           echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
           echo "duration=$DURATION" >> $GITHUB_OUTPUT

--- a/STAGING_TEST_REPORT.md
+++ b/STAGING_TEST_REPORT.md
@@ -224,6 +224,45 @@ All M3 acceptance criteria met:
 
 ---
 
+## 📊 Monitor: Activation
+
+**Status:** ✅ **ACTIVE**  
+**Activated:** 2025-10-06T09:23:50Z  
+**First Run:** [#18276275547](https://github.com/robnreb1/cerply/actions/runs/18276275547)  
+**Commit SHA:** f9cd9f7  
+**Schedule:** Every 15 minutes (cron: `*/15 * * * *`)
+
+### First Run Results
+
+| Metric | Value |
+|--------|-------|
+| **Status** | ✅ PASSED |
+| **Duration** | 6s |
+| **Smoke Tests** | 31/31 passed |
+| **Timestamp** | 2025-10-06T09:27:33Z |
+| **Run Number** | 2 |
+
+### Monitoring Status
+
+- ✅ Workflow scheduled and active
+- ✅ Smoke tests running successfully
+- ✅ Reporter generating metrics
+- ⚠️ Auto-commit to staging blocked by branch protection (acceptable - reports available in artifacts)
+- ✅ Failure detection ready (will create GitHub issues)
+
+### Next Scheduled Runs
+
+- Run #3: 2025-10-06T09:30:00Z (estimated)
+- Run #4: 2025-10-06T09:45:00Z (estimated)
+- Continues every 15 minutes...
+
+### Artifacts
+
+- **Smoke Logs:** Available in [run artifacts](https://github.com/robnreb1/cerply/actions/runs/18276275547)
+- **Monitor Report:** Generated successfully (see artifacts)
+
+---
+
 ## 🎯 Next Steps
 
 1. **Monitor staging for 24 hours** - Watch for any errors in logs


### PR DESCRIPTION
## 🎯 Purpose

Adds `force_fail` boolean input to M3 Staging Monitor for testing auto-issue creation.

**Changes:**
- Add workflow_dispatch input: `force_fail` (boolean, default: false)
- When true: exits with code 2 after printing FORCED FAILURE marker
- Does NOT affect default scheduled behavior (runs every 15min)

**Testing:**
```bash
gh workflow run "M3 Staging Monitor (24h)" -f force_fail=true
```

**Expected:** Creates GitHub issue with title "M3: Staging monitor failure (<timestamp>)"

**For:** Step 2 of M3 deployment (prove alerting works)

**BRD/FSD:** B1/B2/B8/B9, §21/§21.1