### PR TITLE
fix(ci): only tag staging branch as staging-latest (CRITICAL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -680,9 +680,9 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/cerply-api
           tags: |
             type=sha,format=long
-            # Tag staging and staging-latest on both staging and main to keep Render staging current
-            type=raw,value=staging,enable=${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' }}
-            type=raw,value=staging-latest,enable=${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' }}
+            # Tag staging and staging-latest ONLY from staging branch
+            type=raw,value=staging,enable=${{ github.ref == 'refs/heads/staging' }}
+            type=raw,value=staging-latest,enable=${{ github.ref == 'refs/heads/staging' }}
             # On main, publish prod-candidate and a short sha tag for promotion
             type=raw,value=prod-candidate,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,format=short,prefix=sha-,enable=${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## 🚨 **CRITICAL BUG FIX**

### Problem

The CI workflow was tagging **BOTH** `staging` and `main` branches as `staging-latest`:

```yaml
# BEFORE (BROKEN):
type=raw,value=staging-latest,enable=${{ github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main' }}
```

**Impact:**
- When PR #215 merged to `main` (SHA `9dff442`), it **overwrote** the real staging build (SHA `7926c25`)
- Production promotion workflow promoted **wrong image** (main branch instead of staging)
- Production is stuck on old code (`39165b5` from Oct 5)

---

### Root Cause

From Docker image registry:
```
# Current staging-latest (WRONG):
{"created":"2025-10-07T08:24:22Z","tags":["sha-9dff442","staging","staging-latest"]}
↑ This is from main branch!

# Real staging build (CORRECT but untagged):
{"created":"2025-10-07T07:28:48Z","tags":["sha-7926c25ef12861ed89efae4bded76a3e4f05a8a8"]}
↑ This has all the PLATFORM_FOUNDATIONS_v1 fixes but NO staging-latest tag
```

---

### Fix

```yaml
# AFTER (FIXED):
type=raw,value=staging-latest,enable=${{ github.ref == 'refs/heads/staging' }}
```

**Result:** Only `staging` branch builds will tag `staging-latest`, preventing future overwrites.

---

### Deployment Plan (After This Merges)

1. ✅ Merge this PR to `main`
2. ✅ Merge `main` → `staging` (to get this fix)
3. 🔄 Trigger rebuild of `staging` branch (to retag `staging-latest` correctly)
4. 🚀 Re-run `promote-prod.yml` workflow (to promote correct image)
5. ✅ Verify production has latest code

---

### Verification

After deployment:
```bash
curl https://api.cerply.com/api/version | jq '.gitSha'
# Expected: 7926c25... or newer (not 39165b5)
```

---

**Priority:** BLOCKER - prevents production deployment  
**Related:** #209, #215, #217