### PR TITLE
debug(epic9): add logging to diagnose route registration

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -175,7 +175,9 @@ export async function createApp() {
   await safeRegister('./routes/chat-learning', ['registerChatLearningRoutes']);
 
   // Adaptive Difficulty routes (Epic 9: True Adaptive Difficulty Engine)
+  app.log.info('[Epic9] Attempting to register adaptive routes...');
   await safeRegister('./routes/adaptive', ['registerAdaptiveRoutes']);
+  app.log.info('[Epic9] Adaptive routes registration complete');
 
   // Prompts routes for M2 proxy compatibility
   await safeRegister('./routes/prompts', ['registerPromptsRoutes']);

--- a/api/src/routes/adaptive.ts
+++ b/api/src/routes/adaptive.ts
@@ -25,6 +25,8 @@ import { eq } from 'drizzle-orm';
 const FF_ADAPTIVE_DIFFICULTY_V1 = process.env.FF_ADAPTIVE_DIFFICULTY_V1 === 'true';
 
 export async function registerAdaptiveRoutes(app: FastifyInstance) {
+  // Epic 9: Debug logging for route registration
+  app.log.info(`[Epic9] Registering adaptive routes (FF_ADAPTIVE_DIFFICULTY_V1=${FF_ADAPTIVE_DIFFICULTY_V1})`);
   /**
    * GET /api/adaptive/profile/:userId
    * Get learner profile with learning style and weak topics


### PR DESCRIPTION
## Debug Logging for Epic 9 Deployment Issue

**Problem:** Adaptive routes return 404 on Render staging/prod despite feature flag being enabled.

**Solution:** Add debug logging to:
1. Confirm route registration is attempted (`index.ts`)
2. Show feature flag value when routes are registered (`adaptive.ts`)

**Expected Render Logs:**
```
[Epic9] Attempting to register adaptive routes...
[Epic9] Registering adaptive routes (FF_ADAPTIVE_DIFFICULTY_V1=true)
[Epic9] Adaptive routes registration complete
```

This will help identify if:
- Routes aren't being registered (missing log lines)
- Feature flag is being read incorrectly (shows false)
- Something else is wrong

**Safe to merge immediately** - only adds logging, no functional changes.