### PR TITLE
fix(cors): Enable credentials for staging cross-domain auth

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -18,12 +18,26 @@ export async function createApp() {
     }
   };
   
-  // CORS — allow credentials for local development, wildcard for production/test
+  // CORS — allow credentials for local development and staging, wildcard for production/test
   const isDev = process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
   const isTest = process.env.NODE_ENV === 'test';
+  const isStaging = process.env.RENDER_SERVICE_NAME?.includes('staging');
+  
+  // Allow credentials for dev and staging
+  const allowCredentials = isDev || isStaging;
+  
+  // Define allowed origins
+  const allowedOrigins = isTest 
+    ? '*' 
+    : isDev 
+      ? ['http://localhost:3000', 'http://127.0.0.1:3000']
+      : isStaging
+        ? ['https://cerply-staging.vercel.app', 'http://localhost:3000', 'http://127.0.0.1:3000']
+        : '*';
+  
   await app.register(cors, { 
-    origin: isTest ? '*' : (isDev ? ['http://localhost:3000', 'http://127.0.0.1:3000'] : '*'),
-    credentials: isDev ? true : false,
+    origin: allowedOrigins,
+    credentials: allowCredentials,
     methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['content-type', 'authorization', 'x-admin-token', 'x-org-id', 'x-idempotency-key']
   });


### PR DESCRIPTION
## Problem
Epic 14 UAT testing blocked by CORS - staging web app (cerply-staging.vercel.app) can't send/receive session cookies from API (cerply-api-staging-latest.onrender.com).

## Solution
- Allow `cerply-staging.vercel.app` origin with `credentials: true`
- Detect staging environment via `RENDER_SERVICE_NAME` env var
- Keep localhost origins for local testing

## Testing
After deploy:
```bash
# 1. Go to staging login:
https://cerply-staging.vercel.app/login

# 2. Enter any email and submit - should get magic link
# 3. Click callback URL - should set cookie and redirect back
# 4. Should be logged in with session
```

## Impact
- Unblocks Epic 14 UAT testing
- No impact on production (still uses wildcard CORS)
- No impact on dev (still uses localhost)