### PR TITLE
fix(web): Cross-domain session cookie support for dev login

### DIFF
--- a/web/app/dev/login-manager/page.tsx
+++ b/web/app/dev/login-manager/page.tsx
@@ -1,37 +1,26 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { apiBase } from '@/lib/apiBase';
+import { useEffect } from 'react';
 
 /**
  * Dev Login Helper for Manager Role
- * Hits the backend API directly to set session cookie, then redirects
+ * Uses Next.js API proxy which rewrites cookies for same-domain
  */
 export default function DevLoginManagerPage() {
-  const [status, setStatus] = useState('Logging in as manager...');
-
   useEffect(() => {
-    const performLogin = async () => {
-      try {
-        const redirectUrl = `${window.location.origin}/`;
-        const apiUrl = `${apiBase()}/api/dev/login-as-manager?redirect=${encodeURIComponent(redirectUrl)}`;
-        
-        // Use window.location to navigate directly to the API endpoint
-        // This ensures the cookie is set in the browser
-        window.location.href = apiUrl;
-      } catch (err: any) {
-        setStatus(`Error: ${err?.message || String(err)}`);
-      }
-    };
-
-    performLogin();
+    // Redirect to the dev login endpoint through the Next.js proxy
+    // The proxy will rewrite the Set-Cookie header so it works on vercel.app domain
+    const redirectUrl = encodeURIComponent(`${window.location.origin}/`);
+    window.location.href = `/api/dev/login-as-manager?redirect=${redirectUrl}`;
   }, []);
 
   return (
     <div className="flex min-h-dvh items-center justify-center bg-neutral-50">
       <div className="w-full max-w-md rounded-lg border bg-white p-8 shadow-sm">
         <h1 className="mb-6 text-center text-2xl font-medium">Dev Login</h1>
-        <p className="text-center text-sm text-neutral-600">{status}</p>
+        <p className="text-center text-sm text-neutral-600">
+          Logging in as manager...
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Problem

The dev login endpoints (, ) set session cookies from the backend API domain (), but these cookies are not accessible to the frontend on a different domain ().

This prevents the dev login flow from working on staging (Vercel + Render).

## Solution

Updated the Next.js API proxy to **rewrite  headers** for dev login endpoints:
- Removes the  attribute from cookies
- Browser then sets cookies for the current domain (Vercel)
- Session cookies now work correctly across staging environments

## Testing

1. Visit 
2. Should redirect through proxy → API → back to home
3. Should be logged in as manager with working session

## Changes

- `web/app/api/[...path]/route.ts`: Added Set-Cookie header rewriting for dev login paths
- `web/app/dev/login-manager/page.tsx`: Simplified to use proxy endpoint directly

## Related

- Epic 14 (Manager Module Workflows) UAT
- Staging environment setup